### PR TITLE
feat: change the export name of the plugin

### DIFF
--- a/.changeset/lazy-snails-own.md
+++ b/.changeset/lazy-snails-own.md
@@ -1,0 +1,5 @@
+---
+"excss": patch
+---
+
+feat: change the export name of the plugin

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Install excss.
 `npm i excss` `pnpm i excss` `yarn add excss`
 
 Setup the compiler according to the bundler.
+
 ```js
 // next.config.js
 const { createExcss } = require("excss/next");

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Install excss.
 
 `npm i excss` `pnpm i excss` `yarn add excss`
 
-Setup the compiler according to the bundler.
+Setting up the compiler based on the bundler.
 
 ```js
 // next.config.js

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ export function Component(props: Props) {
               background-color: black;
             }
 
+            @media screen and (max-width: $sm) {
+              background-color: black;
+            }
+
             &:hover {
               background-color: green;
             }
@@ -66,4 +70,63 @@ export function Component(props: Props) {
     </div>
   );
 }
+```
+
+## Setups
+
+Install excss.
+
+`npm i excss` `pnpm i excss` `yarn add excss`
+
+Setup the compiler according to the bundler.
+```js
+// next.config.js
+const { createExcss } = require("excss/next");
+
+const withExcss = createExcss({
+  // excss options
+});
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = withExcss(nextConfig);
+```
+
+```ts
+// vite.config.ts
+import { Excss } from "excss/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    Excss({
+      // excss options
+    }),
+  ],
+});
+```
+
+```js
+// webpack.config.js
+const { ExcssPlugin } = require("excss/webpack");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+module.exports = {
+  // webpack options
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+    ],
+  },
+  plugins: [
+    new ExcssPlugin({
+      // excss options
+    }),
+    new MiniCssExtractPlugin(),
+  ],
+};
 ```

--- a/packages/excss/src/plugins/next.ts
+++ b/packages/excss/src/plugins/next.ts
@@ -4,8 +4,8 @@ import { getGlobalCssLoader } from "next/dist/build/webpack/config/blocks/css/lo
 import type { ConfigurationContext } from "next/dist/build/webpack/config/utils";
 import type { Configuration, RuleSetRule } from "webpack";
 import type { Variants } from "../compiler";
-import { ExcssWebpackPlugin } from "./webpack/plugin";
-import type { ExcssWebpackPluginOption } from "./webpack/plugin";
+import type { ExcssOption } from "./webpack/plugin";
+import { ExcssPlugin } from "./webpack/plugin";
 
 type ExcssConfig = {
   /**
@@ -14,13 +14,15 @@ type ExcssConfig = {
   variants?: Variants;
 };
 
-export function createExcssPlugin(excssConfig: ExcssConfig) {
+export { createExcss };
+
+function createExcss(excssConfig: ExcssConfig) {
   return (nextConfig: NextConfig): NextConfig => {
-    return Object.assign({}, nextConfig, excssPlugin(nextConfig, excssConfig));
+    return Object.assign({}, nextConfig, excss(nextConfig, excssConfig));
   };
 }
 
-function excssPlugin(nextConfig: NextConfig, excssConfig: ExcssConfig) {
+function excss(nextConfig: NextConfig, excssConfig: ExcssConfig) {
   return {
     webpack(config: Configuration & ConfigurationContext, options) {
       const { dir, dev, isServer, config: resolvedNextConfig } = options;
@@ -60,12 +62,12 @@ function excssPlugin(nextConfig: NextConfig, excssConfig: ExcssConfig) {
 
       const isAppDir = resolvedNextConfig.experimental.appDir ?? true;
 
-      const excssWebpackPluginOption: ExcssWebpackPluginOption = {
+      const excssWebpackPluginOption: ExcssOption = {
         cssOutDir: isAppDir ? "./.next/cache/excss" : undefined,
         variants: excssConfig.variants,
       };
 
-      config.plugins?.push(new ExcssWebpackPlugin(excssWebpackPluginOption));
+      config.plugins?.push(new ExcssPlugin(excssWebpackPluginOption));
 
       if (typeof nextConfig.webpack === "function") {
         return nextConfig.webpack(config, options) as unknown;

--- a/packages/excss/src/plugins/vite.ts
+++ b/packages/excss/src/plugins/vite.ts
@@ -3,14 +3,14 @@ import * as vite from "vite";
 import type { Variants } from "../compiler";
 import { transform } from "../compiler";
 
-export { ExcssVitePlugin };
+export { excss, excss as Excss };
 
 const DEFAULT_INCLUDE = /\.(js|jsx|ts|tsx)$/;
 
 const VIRTUAL_MODULE_ID = "virtual:ex.css";
 const RESOLVED_VIRTUAL_MODULE_ID = "\0" + VIRTUAL_MODULE_ID;
 
-type ExcssViteOption = {
+type ExcssOption = {
   /**
    * @default /\.(js|jsx|ts|tsx)$/
    */
@@ -29,7 +29,7 @@ type ExcssViteOption = {
   inject?: string | undefined;
 };
 
-function ExcssVitePlugin(option?: ExcssViteOption): Vite.Plugin {
+function excss(option?: ExcssOption): Vite.Plugin {
   const filter = vite.createFilter(
     option?.include ?? DEFAULT_INCLUDE,
     option?.exclude,

--- a/packages/excss/src/plugins/webpack/loader.ts
+++ b/packages/excss/src/plugins/webpack/loader.ts
@@ -10,14 +10,14 @@ type WebpackLoaderParams = Parameters<LoaderDefinitionFunction<never>>;
 const virtualLoader = "excss/webpack/virtualLoader";
 const virtualCSS = "excss/assets/ex.css";
 
-export type ExcssWebpackLoaderOption = {
+export type ExcssLoaderOption = {
   cssOutDir?: string | undefined;
   variants?: Variants | undefined;
   inject?: string | undefined;
 };
 
-export function ExcssWebpackLoader(
-  this: LoaderContext<ExcssWebpackLoaderOption>,
+function excssLoader(
+  this: LoaderContext<ExcssLoaderOption>,
   code: WebpackLoaderParams[0],
   map: WebpackLoaderParams[1],
 ) {
@@ -77,4 +77,4 @@ function createCSSImportCode(
   }
 }
 
-export default ExcssWebpackLoader;
+export default excssLoader;

--- a/packages/excss/src/plugins/webpack/plugin.ts
+++ b/packages/excss/src/plugins/webpack/plugin.ts
@@ -1,11 +1,11 @@
 import type { Compiler } from "webpack";
-import type { ExcssWebpackLoaderOption } from "./loader";
+import type { ExcssLoaderOption } from "./loader";
 
-export type ExcssWebpackPluginOption = ExcssWebpackLoaderOption;
+export type ExcssOption = ExcssLoaderOption;
 
-export class ExcssWebpackPlugin {
-  option: ExcssWebpackPluginOption;
-  constructor(option?: ExcssWebpackPluginOption) {
+class ExcssPlugin {
+  option: ExcssOption;
+  constructor(option?: ExcssOption) {
     this.option = option ?? {};
   }
   apply(compiler: Compiler): void {
@@ -21,3 +21,5 @@ export class ExcssWebpackPlugin {
     });
   }
 }
+
+export { ExcssPlugin };

--- a/packages/excss/src/plugins/webpack/virtualLoader.ts
+++ b/packages/excss/src/plugins/webpack/virtualLoader.ts
@@ -1,8 +1,8 @@
 import type { LoaderContext } from "webpack";
 
-function VirtualLoader(this: LoaderContext<{ src: string }>) {
+function virtualLoader(this: LoaderContext<{ src: string }>) {
   const { src } = this.getOptions();
   this.callback(undefined, src);
 }
 
-export default VirtualLoader;
+export default virtualLoader;

--- a/playground/next/next.config.js
+++ b/playground/next/next.config.js
@@ -1,11 +1,11 @@
 const createBundleAnalyzer = require("@next/bundle-analyzer");
-const { createExcssPlugin } = require("excss/next");
+const { createExcss } = require("excss/next");
 
 const withBundleAnalyzer = createBundleAnalyzer({
   enabled: process.env["ANALYZE"] === "true",
 });
 
-const withExcss = createExcssPlugin({
+const withExcss = createExcss({
   variants: {
     primary: "green",
     sm: '"max-width: 300px"',

--- a/playground/react-vite/vite.config.ts
+++ b/playground/react-vite/vite.config.ts
@@ -1,5 +1,5 @@
 import React from "@vitejs/plugin-react";
-import { ExcssVitePlugin } from "excss/vite";
+import { Excss } from "excss/vite";
 import { defineConfig } from "vite";
 import Inspect from "vite-plugin-inspect";
 
@@ -10,7 +10,7 @@ export default defineConfig({
   },
   plugins: [
     React(),
-    ExcssVitePlugin({
+    Excss({
       variants: {
         red: "#ff0000",
       },

--- a/playground/react-webpack/webpack.config.cjs
+++ b/playground/react-webpack/webpack.config.cjs
@@ -1,5 +1,5 @@
 const path = require("node:path");
-const { ExcssWebpackPlugin } = require("excss/webpack");
+const { ExcssPlugin } = require("excss/webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
@@ -40,7 +40,7 @@ module.exports = {
     filename: "[name].js",
   },
   plugins: [
-    new ExcssWebpackPlugin(),
+    new ExcssPlugin(),
     new HtmlWebpackPlugin({ template: path.join(__dirname, "index.html") }),
     new MiniCssExtractPlugin(),
   ],

--- a/playground/solid-vite/vite.config.ts
+++ b/playground/solid-vite/vite.config.ts
@@ -1,4 +1,4 @@
-import { ExcssVitePlugin } from "excss/vite";
+import { Excss } from "excss/vite";
 import { defineConfig } from "vite";
 import Inspect from "vite-plugin-inspect";
 import Solid from "vite-plugin-solid";
@@ -10,7 +10,7 @@ export default defineConfig({
   },
   plugins: [
     Solid(),
-    ExcssVitePlugin(),
+    Excss(),
     Inspect({
       build: true,
       outputDir: ".inspect",


### PR DESCRIPTION
BREAKING CHANGE

### webpack
`ExcssWebpackPlugin` -> `ExcssPlugin`
### next
`createExcssPlugin` -> `createExcss`
### vite
`ExcssVitePlugin` -> `Excss` | `excss`
