### PR TITLE
chore: retry github releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "retry-release",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@excss/playground-*"]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "retry-release",
   "updateInternalDependencies": "patch",
   "ignore": ["@excss/playground-*"]
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: release
 on:
   push:
     branches:
-      - retry-release
+      - main
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: release
 on:
-  pull_request:
+  push:
     branches:
       - retry-release
   workflow_dispatch:
@@ -16,7 +16,7 @@ jobs:
       - run: pnpm run test
       - uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish --dry-run
+          publish: pnpm changeset publish --dry-run --no-git-checks
           commit: "publish packages"
           title: "chore(changesets): 🦋 publish packages"
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: pnpm run test
       - uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish --dry-run --no-git-checks
+          publish: pnpm changeset tag
           commit: "publish packages"
           title: "chore(changesets): 🦋 publish packages"
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: release
 on:
-  push:
+  pull_request:
     branches:
-      - main
+      - retry-release
   workflow_dispatch:
 jobs:
   release:
@@ -16,7 +16,7 @@ jobs:
       - run: pnpm run test
       - uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          publish: pnpm changeset publish --dry-run
           commit: "publish packages"
           title: "chore(changesets): 🦋 publish packages"
         env:


### PR DESCRIPTION
In #25, publishing to npm was successful, but since the GitHub releases weren't generated, I'll try again.