### PR TITLE
feat: change export method for plugins from named export to default export

### DIFF
--- a/.changeset/olive-elephants-smash.md
+++ b/.changeset/olive-elephants-smash.md
@@ -1,0 +1,16 @@
+---
+"excss": minor
+---
+
+feat: change export method for plugins from named export to default export
+
+```diff
+-import { Excss } from "excss/vite";
++import Excss from "excss/vite";
+
+-import { ExcssPlugin } from "excss/webpack";
++import ExcssPlugin from "excss/webpack";
+
+-import { createExcss } from "excss/next";
++import createExcss from "excss/next";
+```

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,7 +63,9 @@
         "./**/next.config.mjs",
         "./**/webpack.config.mjs",
         "./packages/excss/src/compiler.ts",
-        "./packages/excss/src/plugins/webpack/{virtualLoader,loader}.ts",
+        "./packages/excss/src/plugins/vite.ts",
+        "./packages/excss/src/plugins/next.ts",
+        "./packages/excss/src/plugins/webpack/{virtualLoader,loader,plugin}.ts",
         "./playground/next/src/app/**/{page,layout,loading,error,template,head}.tsx",
         "./playground/next/src/pages/**"
       ],

--- a/README.md
+++ b/README.md
@@ -81,39 +81,39 @@ Install excss.
 Setting up the compiler based on the bundler.
 
 ```js
-// next.config.js
-const { createExcss } = require("excss/next");
+// next.config.mjs
+import createExcss from "excss/next";
 
 const withExcss = createExcss({
-  // excss options
+  /* excss options */
 });
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-module.exports = withExcss(nextConfig);
+export default withExcss(nextConfig);
 ```
 
 ```ts
 // vite.config.ts
-import { Excss } from "excss/vite";
+import Excss from "excss/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [
     Excss({
-      // excss options
+      /* excss options */
     }),
   ],
 });
 ```
 
 ```js
-// webpack.config.js
-const { ExcssPlugin } = require("excss/webpack");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+// webpack.config.mjs
+import ExcssPlugin from "excss/webpack";
+import MiniCssExtractPlugin from "mini-css-extract-plugin";
 
-module.exports = {
+export default {
   // webpack options
   module: {
     rules: [
@@ -125,7 +125,7 @@ module.exports = {
   },
   plugins: [
     new ExcssPlugin({
-      // excss options
+      /* excss options */
     }),
     new MiniCssExtractPlugin(),
   ],

--- a/packages/excss/src/ex.ts
+++ b/packages/excss/src/ex.ts
@@ -7,7 +7,7 @@ import type {
 
 const DEFAULT = "default";
 
-namespace Ex {
+export namespace Ex {
   export type ClassName = ClassName[] | string | false | null | undefined;
 
   export type Required<

--- a/packages/excss/src/ex.ts
+++ b/packages/excss/src/ex.ts
@@ -5,9 +5,6 @@ import type {
   Optional as _Optional,
 } from "./utils/types.ts";
 
-export { ex };
-export type { Ex };
-
 const DEFAULT = "default";
 
 namespace Ex {
@@ -37,17 +34,6 @@ namespace Ex {
         Required extends Exclude<keyof T, undefined> ? Required : never
       >;
 }
-
-type Ex<T extends RawCallback> = Pretty<Exclude<Parameters<T>[0], undefined>>;
-
-function ex<T>(input: Input<T>) {
-  const bind = { _input: input as RawInput };
-  return callback.bind(bind) as (props?: Props<T> | undefined) => string;
-}
-
-ex.join = function (...classNames: Ex.ClassName[]) {
-  return resolveClassName(classNames);
-};
 
 type Props<T> = Pretty<{
   [K in Exclude<keyof T, typeof DEFAULT>]?:
@@ -122,3 +108,16 @@ function resolveClassName(className: Ex.ClassName): string {
     return "";
   }
 }
+
+export type Ex<T extends RawCallback> = Pretty<
+  Exclude<Parameters<T>[0], undefined>
+>;
+
+export function ex<T>(input: Input<T>) {
+  const bind = { _input: input as RawInput };
+  return callback.bind(bind) as (props?: Props<T> | undefined) => string;
+}
+
+ex.join = function (...classNames: Ex.ClassName[]) {
+  return resolveClassName(classNames);
+};

--- a/packages/excss/src/plugins/next.ts
+++ b/packages/excss/src/plugins/next.ts
@@ -69,10 +69,8 @@ function plugin(nextConfig: NextConfig, excssConfig: ExcssConfig) {
   } as NextConfig;
 }
 
-function createPlugin(excssConfig: ExcssConfig) {
+export default function createPlugin(excssConfig: ExcssConfig) {
   return (nextConfig: NextConfig): NextConfig => {
     return Object.assign({}, nextConfig, plugin(nextConfig, excssConfig));
   };
 }
-
-export default createPlugin;

--- a/packages/excss/src/plugins/next.ts
+++ b/packages/excss/src/plugins/next.ts
@@ -4,7 +4,7 @@ import { getGlobalCssLoader } from "next/dist/build/webpack/config/blocks/css/lo
 import type { ConfigurationContext } from "next/dist/build/webpack/config/utils.js";
 import type { Configuration, RuleSetRule } from "webpack";
 import type { ExcssOption } from "./webpack/plugin.ts";
-import { ExcssPlugin } from "./webpack/plugin.ts";
+import ExcssPlugin from "./webpack/plugin.ts";
 
 type ExcssConfig = {
   /**
@@ -13,15 +13,7 @@ type ExcssConfig = {
   inject?: string;
 };
 
-export { createExcss };
-
-function createExcss(excssConfig: ExcssConfig) {
-  return (nextConfig: NextConfig): NextConfig => {
-    return Object.assign({}, nextConfig, excss(nextConfig, excssConfig));
-  };
-}
-
-function excss(nextConfig: NextConfig, excssConfig: ExcssConfig) {
+function plugin(nextConfig: NextConfig, excssConfig: ExcssConfig) {
   return {
     webpack(config: Configuration & ConfigurationContext, options) {
       const { dir, dev, isServer, config: resolvedNextConfig } = options;
@@ -76,3 +68,11 @@ function excss(nextConfig: NextConfig, excssConfig: ExcssConfig) {
     },
   } as NextConfig;
 }
+
+function createPlugin(excssConfig: ExcssConfig) {
+  return (nextConfig: NextConfig): NextConfig => {
+    return Object.assign({}, nextConfig, plugin(nextConfig, excssConfig));
+  };
+}
+
+export default createPlugin;

--- a/packages/excss/src/plugins/vite.ts
+++ b/packages/excss/src/plugins/vite.ts
@@ -5,8 +5,6 @@ import type * as Vite from "vite";
 import * as vite from "vite";
 import { generateFileId } from "../utils/generateFileId.ts";
 
-export { excss, excss as Excss };
-
 const DEFAULT_INCLUDE = /\.(js|jsx|ts|tsx)$/;
 
 const VIRTUAL_MODULE_ID = "virtual:ex.css";
@@ -27,7 +25,7 @@ type ExcssOption = {
   inject?: string | undefined;
 };
 
-function excss(option?: ExcssOption): Vite.Plugin {
+function plugin(option?: ExcssOption): Vite.Plugin {
   const filter = vite.createFilter(
     option?.include ?? DEFAULT_INCLUDE,
     option?.exclude,
@@ -106,3 +104,5 @@ function excss(option?: ExcssOption): Vite.Plugin {
     },
   };
 }
+
+export default plugin;

--- a/packages/excss/src/plugins/webpack/loader.ts
+++ b/packages/excss/src/plugins/webpack/loader.ts
@@ -18,7 +18,7 @@ export type ExcssLoaderOption = {
   configDependencies: string[];
 };
 
-function excssLoader(
+export default function excssLoader(
   this: LoaderContext<ExcssLoaderOption>,
   code: WebpackLoaderParams[0],
   map: WebpackLoaderParams[1],
@@ -91,5 +91,3 @@ function createCSSImportCode(
     )};`;
   }
 }
-
-export default excssLoader;

--- a/packages/excss/src/plugins/webpack/plugin.ts
+++ b/packages/excss/src/plugins/webpack/plugin.ts
@@ -12,7 +12,7 @@ type PackageJson = {
   name?: string;
 };
 
-class ExcssPlugin {
+class Plugin {
   loaderOption: ExcssLoaderOption;
   packageJsonPath = path.join(process.cwd(), "package.json");
 
@@ -53,4 +53,4 @@ class ExcssPlugin {
   }
 }
 
-export { ExcssPlugin };
+export default Plugin;

--- a/packages/excss/src/plugins/webpack/plugin.ts
+++ b/packages/excss/src/plugins/webpack/plugin.ts
@@ -12,7 +12,7 @@ type PackageJson = {
   name?: string;
 };
 
-class Plugin {
+export default class Plugin {
   loaderOption: ExcssLoaderOption;
   packageJsonPath = path.join(process.cwd(), "package.json");
 
@@ -52,5 +52,3 @@ class Plugin {
     });
   }
 }
-
-export default Plugin;

--- a/packages/excss/src/plugins/webpack/virtualLoader.ts
+++ b/packages/excss/src/plugins/webpack/virtualLoader.ts
@@ -1,8 +1,6 @@
 import type { LoaderContext } from "webpack";
 
-function virtualLoader(this: LoaderContext<{ src: string }>) {
+export default function virtualLoader(this: LoaderContext<{ src: string }>) {
   const { src } = this.getOptions();
   this.callback(undefined, src);
 }
-
-export default virtualLoader;

--- a/playground/next/next.config.mjs
+++ b/playground/next/next.config.mjs
@@ -1,6 +1,6 @@
 import createBundleAnalyzer from "@next/bundle-analyzer";
 import { variants } from "excss/config";
-import { createExcss } from "excss/next";
+import createExcss from "excss/next";
 
 const withBundleAnalyzer = createBundleAnalyzer({
   enabled: process.env["ANALYZE"] === "true",

--- a/playground/react-vite/vite.config.ts
+++ b/playground/react-vite/vite.config.ts
@@ -1,6 +1,6 @@
 import React from "@vitejs/plugin-react-swc";
 import { variants } from "excss/config";
-import { Excss } from "excss/vite";
+import Excss from "excss/vite";
 import { defineConfig } from "vite";
 import Inspect from "vite-plugin-inspect";
 

--- a/playground/react-webpack/webpack.config.mjs
+++ b/playground/react-webpack/webpack.config.mjs
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { ExcssPlugin } from "excss/webpack";
+import ExcssPlugin from "excss/webpack";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 

--- a/playground/solid-vite/vite.config.ts
+++ b/playground/solid-vite/vite.config.ts
@@ -1,4 +1,4 @@
-import { Excss } from "excss/vite";
+import Excss from "excss/vite";
 import { defineConfig } from "vite";
 import Inspect from "vite-plugin-inspect";
 import Solid from "vite-plugin-solid";


### PR DESCRIPTION
⚠️ BREAKING CHANGE !!

## Before
```ts
import { Excss } from "excss/vite";
import { ExcssPlugin } from "excss/webpack";
import { createExcss } from "excss/next";
```

## After
```ts
import Excss from "excss/vite";
import ExcssPlugin from "excss/webpack";
import createExcss from "excss/next";
```